### PR TITLE
[DH-475] Upgrade lifelines package to version 0.30.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -133,7 +133,7 @@ dependencies:
   - jupysql==0.10.17
 
   # Econ 148; Spring 2025; https://github.com/berkeley-dsep-infra/datahub/issues/6872
-  - lifelines==0.27.8
+  - lifelines==0.30.0
 
   - pip:
     - git-credential-helpers==0.2


### PR DESCRIPTION
Silas gave a thumps up to bump lifeline package version to 0.30.0 - https://github.com/berkeley-dsep-infra/datahub/issues/6872#issuecomment-2719380623