### PR TITLE
Add pytorch to the datahub base image as requested by Physics77 instructor

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -135,6 +135,9 @@ dependencies:
   # Econ 148; Spring 2025; https://github.com/berkeley-dsep-infra/datahub/issues/6872
   - lifelines==0.30.0
 
+  # Physics 77/88; Fall 2025; 
+  - pytorch==2.5.1
+
   - pip:
     - git-credential-helpers==0.2
     - jupyter-shiny-proxy==1.3.0


### PR DESCRIPTION
@PhysMa Please let me know if you still want `Pytorch` installed in DataHub