### PR TITLE
Enable GitHub Copilot in RStudio.

### DIFF
--- a/rsession.conf
+++ b/rsession.conf
@@ -1,2 +1,5 @@
 # Use binary packages!
 r-cran-repos=https://packagemanager.posit.co/cran/__linux__/jammy/2025-01-02
+
+# Enable GitHub Copilot
+copilot-enabled=1


### PR DESCRIPTION
This is documented in https://docs.posit.co/ide/user/ide/guide/tools/copilot.html. Related to https://jira-secure.berkeley.edu/browse/DH-550.