### PR TITLE
[DH-563] Bump JupyterLab and Notebook version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,12 +14,12 @@ dependencies:
   - jupyter-server-proxy==4.4.0
   - jupyter_server==2.16.0 
   - jupyterhub==5.3.0
-  - jupyterlab==4.4.2
+  - jupyterlab==4.4.3
   - jupyterlab-git==0.51.1
   - jupyterlab_rise==0.43.1
   - jupytext==1.17.1
   - nbgitpuller==1.2.2
-  - notebook==7.4.2
+  - notebook==7.4.3
   - otter-grader==6.1.3
   - pip==25.1.1  
   - python==3.11.*


### PR DESCRIPTION
to mimic the versions in Data8 and Data100 hubs and to resolve the issue reported by @yanlisa in `ucb-datahubs` slack channel.