### PR TITLE
pin pyjwt to a version <2.11.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -141,7 +141,7 @@ dependencies:
   - geojson==3.2.0
   - pyproj==3.7.2
 
-  # DH-654, Make git-credentials-helper work for ds4bio course
+  # DH-654, Make git-credentials-helper work
   - pyjwt<2.11.0
 
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -142,7 +142,7 @@ dependencies:
   - pyproj==3.7.2
 
   # DH-654, Make git-credentials-helper work for ds4bio course
-  - pyjwt==2.11.0
+  - pyjwt<2.11.0
 
   - pip:
     - git-credential-helpers==0.2


### PR DESCRIPTION
Based on testing in datahub-staging and biology-staging, Pinning pyjwt to a version < 2.11.0 only makes the nbgitpuller work for private repos. 2.11.0 doesn't cut it